### PR TITLE
Rename package graph-rapid7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-rapid7",
-  "version": "0.3.0",
+  "version": "0.1.0",
   "description": "A JupiterOne Integration",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jupiterone/integration-template",
+  "name": "@jupiterone/graph-rapid7",
   "version": "0.3.0",
   "description": "A JupiterOne Integration",
   "license": "MPL-2.0",


### PR DESCRIPTION
This was publishing packages called `@jupiterone/integration-template`... 🤦 

The good news is we can start back at v0.1.0 since this has never been used or released.