### PR TITLE
Remove entites: [entities.ASSET] from site-assets step

### DIFF
--- a/src/steps/site-assets.ts
+++ b/src/steps/site-assets.ts
@@ -68,7 +68,7 @@ export const siteAssetsSteps: IntegrationStep<IntegrationConfig>[] = [
   {
     id: steps.FETCH_SITE_ASSETS,
     name: 'Fetch Site Assets',
-    entities: [entities.ASSET],
+    entities: [],
     relationships: [
       relationships.SITE_HAS_ASSET,
       relationships.ACCOUNT_HAS_ASSET,


### PR DESCRIPTION
No functional change. This step just doesn't create `entities.ASSET` entity types.