### PR TITLE
Reimplement find or create vuln

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Re-added `insightvm_vulnerability` and `insightvm_finding_is_vulnerability`.
+
 ## 0.2.6 - 2021-02-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - Re-added `insightvm_vulnerability` and `insightvm_finding_is_vulnerability`.
+- Added debug-level logs for `findOrCreateVulnerability()`.
 
 ## 0.2.6 - 2021-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.3.0 - 2021-02-16
+
 ### Added
 
 - Re-added `insightvm_vulnerability` and `insightvm_finding_is_vulnerability`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-rapid7",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "A JupiterOne Integration",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/steps/__snapshots__/index.test.ts.snap
+++ b/src/steps/__snapshots__/index.test.ts.snap
@@ -1378,6 +1378,64 @@ Object {
       "severity": "unknown",
       "status": "vulnerable",
     },
+    Object {
+      "_class": Array [
+        "Vulnerability",
+      ],
+      "_key": "insightvm_vulnerability:unix-user-home-dir-mode",
+      "_rawData": Array [
+        Object {
+          "name": "default",
+          "rawData": Object {
+            "id": "unix-user-home-dir-mode",
+            "instances": 1,
+            "links": Array [
+              Object {
+                "href": "https://localhost:3780/api/3/assets/1/vulnerabilities/unix-user-home-dir-mode",
+                "rel": "self",
+              },
+              Object {
+                "href": "https://localhost:3780/api/3/vulnerabilities/unix-user-home-dir-mode",
+                "id": "unix-user-home-dir-mode",
+                "rel": "Vulnerability",
+              },
+              Object {
+                "href": "https://localhost:3780/api/3/assets/1/vulnerabilities/unix-user-home-dir-mode/validations",
+                "id": "unix-user-home-dir-mode",
+                "rel": "Vulnerability Validations",
+              },
+              Object {
+                "href": "https://localhost:3780/api/3/assets/1/vulnerabilities/unix-user-home-dir-mode/solution",
+                "id": "unix-user-home-dir-mode",
+                "rel": "Vulnerability Solutions",
+              },
+            ],
+            "results": Array [
+              Object {
+                "proof": "<p><p>The permissions for home directory of user extreme was found to be 755 which is more permissive than 750.</p></p>",
+                "since": "2020-09-24T15:06:28.045Z",
+                "status": "vulnerable-version",
+              },
+            ],
+            "since": "2020-09-24T15:06:28.045Z",
+            "status": "vulnerable",
+          },
+        },
+      ],
+      "_type": "insightvm_vulnerability",
+      "active": undefined,
+      "blocking": false,
+      "category": "other",
+      "createdOn": undefined,
+      "displayName": "unix-user-home-dir-mode",
+      "id": "unix-user-home-dir-mode",
+      "name": "unix-user-home-dir-mode",
+      "open": false,
+      "production": false,
+      "public": true,
+      "severity": "critical",
+      "status": "vulnerable",
+    },
   ],
   "collectedRelationships": Array [
     Object {
@@ -1468,6 +1526,14 @@ Object {
       "_type": "insightvm_asset_has_finding",
       "displayName": "HAS",
     },
+    Object {
+      "_class": "IS",
+      "_fromEntityKey": "insightvm_asset_vulnerability:1:unix-user-home-dir-mode",
+      "_key": "insightvm_asset_vulnerability:1:unix-user-home-dir-mode|is|insightvm_vulnerability:unix-user-home-dir-mode",
+      "_toEntityKey": "insightvm_vulnerability:unix-user-home-dir-mode",
+      "_type": "insightvm_finding_is_vulnerability",
+      "displayName": "IS",
+    },
   ],
   "encounteredTypes": Array [
     "insightvm_account",
@@ -1483,8 +1549,10 @@ Object {
     "insightvm_scan_monitors_asset",
     "insightvm_finding",
     "insightvm_asset_has_finding",
+    "insightvm_vulnerability",
+    "insightvm_finding_is_vulnerability",
   ],
-  "numCollectedEntities": 8,
-  "numCollectedRelationships": 11,
+  "numCollectedEntities": 9,
+  "numCollectedRelationships": 12,
 }
 `;

--- a/src/steps/vulnerabilities.test.ts
+++ b/src/steps/vulnerabilities.test.ts
@@ -1,0 +1,90 @@
+import { testFunctions } from './vulnerabilities';
+import { createMockStepExecutionContext } from '@jupiterone/integration-sdk-testing';
+import { IntegrationConfig, InsightVmAssetVulnerability } from '../types';
+
+const { findOrCreateVulnerability, createVulnerabilityEntity } = testFunctions;
+
+const instanceConfig = {
+  insightHost: process.env.INSIGHT_HOST || 'localhost:3780',
+  insightClientUsername: process.env.INSIGHT_CLIENT_USERNAME || 'username',
+  insightClientPassword: process.env.INSIGHT_CLIENT_PASSWORD || 'password',
+};
+
+describe('findOrCreateVulnerability', () => {
+  test('should find vulnerability that has already been created', async () => {
+    const existingVulnerabilityEntity = createVulnerabilityEntity({
+      id: 'vuln-id',
+      instances: 1,
+      links: [],
+      results: [],
+      since: 'since',
+      status: 'status',
+    });
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+      entities: [existingVulnerabilityEntity],
+    });
+
+    const newAssetVulnerability: InsightVmAssetVulnerability = {
+      id: existingVulnerabilityEntity.id,
+      instances: 1,
+      links: [],
+      results: [],
+      since: 'since',
+      status: 'status',
+    };
+
+    await expect(
+      findOrCreateVulnerability(context.jobState, newAssetVulnerability),
+    ).resolves.toBe(existingVulnerabilityEntity);
+    expect(context.jobState.collectedEntities.length).toBe(0);
+  });
+
+  test('should create vulnerability when none exists', async () => {
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+    });
+
+    const newAssetVulnerability: InsightVmAssetVulnerability = {
+      id: 'vuln-id',
+      instances: 1,
+      links: [],
+      results: [],
+      since: 'since',
+      status: 'status',
+    };
+
+    await expect(
+      findOrCreateVulnerability(context.jobState, newAssetVulnerability),
+    ).resolves.toEqual(createVulnerabilityEntity(newAssetVulnerability));
+    expect(context.jobState.collectedEntities.length).toBe(1);
+    expect(context.jobState.collectedEntities[0].id).toBe('vuln-id');
+  });
+
+  test('should not fail if id is undefined', async () => {
+    const context = createMockStepExecutionContext<IntegrationConfig>({
+      instanceConfig,
+    });
+
+    const newAssetVulnerability: InsightVmAssetVulnerability = {
+      id: (undefined as unknown) as string,
+      instances: 1,
+      links: [],
+      results: [],
+      since: 'since',
+      status: 'status',
+    };
+
+    await expect(
+      findOrCreateVulnerability(context.jobState, newAssetVulnerability),
+    ).resolves.toEqual(createVulnerabilityEntity(newAssetVulnerability));
+    expect(context.jobState.collectedEntities.length).toBe(1);
+
+    await expect(
+      findOrCreateVulnerability(context.jobState, newAssetVulnerability),
+    ).resolves.toEqual(createVulnerabilityEntity(newAssetVulnerability));
+    expect(context.jobState.collectedEntities.length).toBe(1);
+
+    expect(context.jobState.collectedEntities[0].id).toBe('undefined');
+  });
+});

--- a/src/steps/vulnerabilities.test.ts
+++ b/src/steps/vulnerabilities.test.ts
@@ -35,7 +35,7 @@ describe('findOrCreateVulnerability', () => {
     };
 
     await expect(
-      findOrCreateVulnerability(context.jobState, newAssetVulnerability),
+      findOrCreateVulnerability(context, newAssetVulnerability),
     ).resolves.toBe(existingVulnerabilityEntity);
     expect(context.jobState.collectedEntities.length).toBe(0);
   });
@@ -55,7 +55,7 @@ describe('findOrCreateVulnerability', () => {
     };
 
     await expect(
-      findOrCreateVulnerability(context.jobState, newAssetVulnerability),
+      findOrCreateVulnerability(context, newAssetVulnerability),
     ).resolves.toEqual(createVulnerabilityEntity(newAssetVulnerability));
     expect(context.jobState.collectedEntities.length).toBe(1);
     expect(context.jobState.collectedEntities[0].id).toBe('vuln-id');
@@ -76,12 +76,12 @@ describe('findOrCreateVulnerability', () => {
     };
 
     await expect(
-      findOrCreateVulnerability(context.jobState, newAssetVulnerability),
+      findOrCreateVulnerability(context, newAssetVulnerability),
     ).resolves.toEqual(createVulnerabilityEntity(newAssetVulnerability));
     expect(context.jobState.collectedEntities.length).toBe(1);
 
     await expect(
-      findOrCreateVulnerability(context.jobState, newAssetVulnerability),
+      findOrCreateVulnerability(context, newAssetVulnerability),
     ).resolves.toEqual(createVulnerabilityEntity(newAssetVulnerability));
     expect(context.jobState.collectedEntities.length).toBe(1);
 

--- a/src/steps/vulnerabilities.ts
+++ b/src/steps/vulnerabilities.ts
@@ -4,7 +4,6 @@ import {
   Entity,
   IntegrationStep,
   IntegrationStepExecutionContext,
-  JobState,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
@@ -46,7 +45,7 @@ export function getVulnerabilityKey(id: string): string {
 }
 
 async function findOrCreateVulnerability(
-  jobState: JobState,
+  { logger, jobState }: IntegrationStepExecutionContext<IntegrationConfig>,
   assetVulnerability: InsightVmAssetVulnerability,
 ): Promise<Entity> {
   const existingVulnerability = await jobState.findEntity(
@@ -54,8 +53,20 @@ async function findOrCreateVulnerability(
   );
 
   if (existingVulnerability) {
+    logger.debug(
+      {
+        id: assetVulnerability.id,
+      },
+      'Found existing vulnerability entity in jobState.',
+    );
     return existingVulnerability;
   }
+  logger.debug(
+    {
+      id: assetVulnerability.id,
+    },
+    'Creating new vulnerability entity in jobState.',
+  );
   return jobState.addEntity(createVulnerabilityEntity(assetVulnerability));
 }
 
@@ -83,11 +94,10 @@ function createVulnerabilityEntity(
   });
 }
 
-export async function fetchAssetVulnerabilities({
-  logger,
-  instance,
-  jobState,
-}: IntegrationStepExecutionContext<IntegrationConfig>) {
+export async function fetchAssetVulnerabilities(
+  context: IntegrationStepExecutionContext<IntegrationConfig>,
+) {
+  const { logger, instance, jobState } = context;
   const apiClient = createAPIClient(instance.config, logger);
 
   await jobState.iterateEntities(
@@ -117,7 +127,7 @@ export async function fetchAssetVulnerabilities({
           );
 
           const vulnerabilityEntity = await findOrCreateVulnerability(
-            jobState,
+            context,
             assetVulnerability,
           );
           await jobState.addRelationship(

--- a/src/steps/vulnerabilities.ts
+++ b/src/steps/vulnerabilities.ts
@@ -56,28 +56,31 @@ async function findOrCreateVulnerability(
   if (existingVulnerability) {
     return existingVulnerability;
   }
+  return jobState.addEntity(createVulnerabilityEntity(assetVulnerability));
+}
 
-  // TODO should fetch vulnerability from `/vulnerabilities/{id} endpoint to create entity.
-  return jobState.addEntity(
-    createIntegrationEntity({
-      entityData: {
-        source: assetVulnerability,
-        assign: {
-          _key: getVulnerabilityKey(assetVulnerability.id),
-          _type: entities.VULNERABILITY._type,
-          _class: entities.VULNERABILITY._class,
-          id: `${assetVulnerability.id}`,
-          name: assetVulnerability.id,
-          category: 'other',
-          severity: 'critical',
-          blocking: false,
-          open: false,
-          production: false,
-          public: true,
-        },
+// TODO should fetch vulnerability from `/vulnerabilities/{id} endpoint to create entity.
+function createVulnerabilityEntity(
+  assetVulnerability: InsightVmAssetVulnerability,
+) {
+  return createIntegrationEntity({
+    entityData: {
+      source: assetVulnerability,
+      assign: {
+        _key: getVulnerabilityKey(assetVulnerability.id),
+        _type: entities.VULNERABILITY._type,
+        _class: entities.VULNERABILITY._class,
+        id: `${assetVulnerability.id}`,
+        name: assetVulnerability.id,
+        category: 'other',
+        severity: 'critical',
+        blocking: false,
+        open: false,
+        production: false,
+        public: true,
       },
-    }),
-  );
+    },
+  });
 }
 
 export async function fetchAssetVulnerabilities({
@@ -152,3 +155,8 @@ export const vulnerabilitiesSteps: IntegrationStep<IntegrationConfig>[] = [
     executionHandler: fetchAssetVulnerabilities,
   },
 ];
+
+export const testFunctions = {
+  findOrCreateVulnerability,
+  createVulnerabilityEntity,
+};

--- a/src/steps/vulnerabilities.ts
+++ b/src/steps/vulnerabilities.ts
@@ -1,10 +1,10 @@
 import {
   createDirectRelationship,
   createIntegrationEntity,
-  // Entity,
+  Entity,
   IntegrationStep,
   IntegrationStepExecutionContext,
-  // JobState,
+  JobState,
   RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 
@@ -45,40 +45,40 @@ export function getVulnerabilityKey(id: string): string {
   return `insightvm_vulnerability:${id}`;
 }
 
-// async function findOrCreateVulnerability(
-//   jobState: JobState,
-//   assetVulnerability: InsightVmAssetVulnerability,
-// ): Promise<Entity> {
-//   const existingVulnerability = await jobState.findEntity(
-//     getVulnerabilityKey(assetVulnerability.id),
-//   );
+async function findOrCreateVulnerability(
+  jobState: JobState,
+  assetVulnerability: InsightVmAssetVulnerability,
+): Promise<Entity> {
+  const existingVulnerability = await jobState.findEntity(
+    getVulnerabilityKey(assetVulnerability.id),
+  );
 
-//   if (existingVulnerability) {
-//     return existingVulnerability;
-//   }
+  if (existingVulnerability) {
+    return existingVulnerability;
+  }
 
-//   // TODO should fetch vulnerability from `/vulnerabilities/{id} endpoint to create entity.
-//   return jobState.addEntity(
-//     createIntegrationEntity({
-//       entityData: {
-//         source: assetVulnerability,
-//         assign: {
-//           _key: getVulnerabilityKey(assetVulnerability.id),
-//           _type: entities.VULNERABILITY._type,
-//           _class: entities.VULNERABILITY._class,
-//           id: `${assetVulnerability.id}`,
-//           name: assetVulnerability.id,
-//           category: 'other',
-//           severity: 'critical',
-//           blocking: false,
-//           open: false,
-//           production: false,
-//           public: true,
-//         },
-//       },
-//     }),
-//   );
-// }
+  // TODO should fetch vulnerability from `/vulnerabilities/{id} endpoint to create entity.
+  return jobState.addEntity(
+    createIntegrationEntity({
+      entityData: {
+        source: assetVulnerability,
+        assign: {
+          _key: getVulnerabilityKey(assetVulnerability.id),
+          _type: entities.VULNERABILITY._type,
+          _class: entities.VULNERABILITY._class,
+          id: `${assetVulnerability.id}`,
+          name: assetVulnerability.id,
+          category: 'other',
+          severity: 'critical',
+          blocking: false,
+          open: false,
+          production: false,
+          public: true,
+        },
+      },
+    }),
+  );
+}
 
 export async function fetchAssetVulnerabilities({
   logger,
@@ -113,18 +113,17 @@ export async function fetchAssetVulnerabilities({
             }),
           );
 
-          /* TODO: Re-implement. Temporarily disabled for testing. */
-          // const vulnerabilityEntity = await findOrCreateVulnerability(
-          //   jobState,
-          //   assetVulnerability,
-          // );
-          // await jobState.addRelationship(
-          //   createDirectRelationship({
-          //     _class: RelationshipClass.IS,
-          //     from: findingEntity,
-          //     to: vulnerabilityEntity,
-          //   }),
-          // );
+          const vulnerabilityEntity = await findOrCreateVulnerability(
+            jobState,
+            assetVulnerability,
+          );
+          await jobState.addRelationship(
+            createDirectRelationship({
+              _class: RelationshipClass.IS,
+              from: findingEntity,
+              to: vulnerabilityEntity,
+            }),
+          );
         },
       );
     },


### PR DESCRIPTION
Added logger.debug statements to inspect the offending `findOrCreateEntity` function, which is causing issues in the deployed infrastructure.