### PR TITLE
INT-5954 - Integration Failure Rapid 7

### DIFF
--- a/.gitleaks.yml
+++ b/.gitleaks.yml
@@ -1,4 +1,0 @@
-[whitelist]
-  files = [
-    "(.*?)(jpg|gif|doc|pdf|bin|lock)$"
-  ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated jupiterone.md docs to correct part about Global Administrator role.
+
 ## [0.4.0] - 2022-12-02
 
 ### Changed

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -38,8 +38,8 @@ Jupiterone requires the following information to complete authentication:
    - The publicly-accessible socket (host:port) of your InsightVM Security
      Console. e.g. <hostname>:3780.
 2. An InsightVM Username and Password
-   - Use an existing user or create a user that has at least the
-     [Security Manager and Site Owner Role](https://docs.rapid7.com/insightvm/managing-users-and-authentication/#security-manager-and-site-owner)
+   - Use an existing user or create a user that has the
+     [Global Administrator Role](https://docs.rapid7.com/insightvm/managing-users-and-authentication/#global-administrator)
 
 ### In JupiterOne
 


### PR DESCRIPTION
The user credentials that are provided in the integration should have a Global Administrator role as stated in [development.md](https://github.com/Creativice-Oy/graph-rapid7/blob/42856aed771b69b2ba6aaa80468d296810068db3/docs/development.md?plain=1#L70-L72). The "All security consoles permission" is the only permission that grants access to the functions related to user accounts which is needed for the integration and there is no other way to have it except for having a Global Administrator role. The permission can not be enabled even for a custom role.

<img width="997" alt="Screenshot 2022-11-24 at 15 58 01" src="https://user-images.githubusercontent.com/13102652/203725800-1d27291c-c130-463a-bf44-95bd1350dc1b.png">
