### PR TITLE
Add error '.cause' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Updated
+
+- Added the `cause` property on API errors for further information
+
+### Fixed
+
+- Check if `accountEntity` exists before building relationships in
+  `build-account-site-relationships`
+
 ## [0.4.1] - 2022-12-15
 
 ### Fixed

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -76,7 +76,7 @@ NOTE: ALL OF THE FOLLOWING DOCUMENTATION IS GENERATED USING THE
 "j1-integration document" COMMAND. DO NOT EDIT BY HAND! PLEASE SEE THE DEVELOPER
 DOCUMENTATION FOR USAGE INFORMATION:
 
-https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
+https://github.com/JupiterOne/sdk/blob/master/docs/integrations/development.md
 ********************************************************************************
 -->
 
@@ -98,7 +98,7 @@ The following entities are created:
 
 ### Relationships
 
-The following relationships are created:
+The following relationships are created/mapped:
 
 | Source Entity `_type` | Relationship `_class` | Target Entity `_type`     |
 | --------------------- | --------------------- | ------------------------- |

--- a/src/client.ts
+++ b/src/client.ts
@@ -65,6 +65,7 @@ export class APIClient {
         endpoint: uri,
         status: response.status,
         statusText: response.statusText,
+        cause: new Error(await response.text()),
       });
     }
     return response;

--- a/src/steps/account-sites.ts
+++ b/src/steps/account-sites.ts
@@ -16,9 +16,8 @@ import {
 export async function fetchAccountSiteRelationships({
   jobState,
 }: IntegrationStepExecutionContext<IntegrationConfig>) {
-  const accountEntity = (await jobState.getData(
-    ACCOUNT_ENTITY_DATA_KEY,
-  )) as Entity;
+  const accountEntity = await jobState.getData<Entity>(ACCOUNT_ENTITY_DATA_KEY);
+  if (!accountEntity) return;
   await jobState.iterateEntities(
     { _type: entities.SITE._type },
     async (siteEntity) => {


### PR DESCRIPTION
### Updated

- Added the `cause` property on API errors for further information

### Fixed

- Check if `accountEntity` exists before building relationships in
  `build-account-site-relationships`